### PR TITLE
Updated authentication method

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -6,12 +6,30 @@ This library is a small handler for Node.js web servers that handles all the log
 
 Inspired by [github-webhook-handler](https://github.com/rvagg/github-webhook-handler).
 
+## Authentication
+The Travis CI webhook notifications are authenticated by public/private key-pair signing and verification.
+
+The handler only accepts authenticated requests.
+
+Please make sure you pass in Travis CI's public key, which can be found [here](https://api.travis-ci.org/config).
+
+```js
+fetch('https://api.travis-ci.org/config')
+  .then((res) => res.text())
+  .then(function(body) {
+    handler = createHandler({
+      path: '/webhook',
+      public_key: JSON.parse(body).config.notifications.webhook.public_key
+    })
+  })
+```
+
 ## Example
 
 ```js
 var http = require('http')
 var createHandler = require('travisci-webhook-handler')
-var handler = createHandler({ path: '/webhook', token: 'mytoken' })
+var handler = createHandler({ path: '/webhook', public_key: 'travisPublicKey' })
 
 http.createServer(function (req, res) {
   handler(req, res, function (err) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "body": "^5.1.0"
+    "body": "^5.1.0",
+    "node-rsa": "^0.4.2"
   },
   "devDependencies": {
     "eslint": "^1.2.1",


### PR DESCRIPTION
Credit to @bneiluj for helping with this.

The existing authentication method has been [deprecated](https://docs.travis-ci.com/user/notifications#Authorization-for-Webhooks-%28Deprecated%29)

This updates the authentication method to use public/private key-pair verification, using SHA1.

Here's details on the new way of authentication webhook notifications from Travis CI: 
[https://docs.travis-ci.com/user/notifications#Verifying-Webhook-requests](https://docs.travis-ci.com/user/notifications#Verifying-Webhook-requests)
